### PR TITLE
Fix stream not being flushed

### DIFF
--- a/lib/rollbar_transport.js
+++ b/lib/rollbar_transport.js
@@ -34,18 +34,17 @@ class RollbarTransport extends TransportStream {
       const meta = info;
       const rollbarLevel = level === 'warn' ? 'warning' : level;
 
-      const logMethod = this.rollbar[rollbarLevel] || this.rollbar.log;
-
-      return logMethod.apply(this.rollbar, [message, meta, cb]);
-
-      function cb(err) {
+      const cb = err => {
         if (err) {
           this.emit('error', err);
           return callback(err);
         }
         this.emit('logged');
         return callback(null, true);
-      }
+      };
+      
+      const logMethod = this.rollbar[rollbarLevel] || this.rollbar.log;
+      return logMethod.apply(this.rollbar, [message, meta, cb.bind(this)]);
     });
   }
 }

--- a/lib/rollbar_transport.js
+++ b/lib/rollbar_transport.js
@@ -44,7 +44,7 @@ class RollbarTransport extends TransportStream {
       };
       
       const logMethod = this.rollbar[rollbarLevel] || this.rollbar.log;
-      return logMethod.apply(this.rollbar, [message, meta, cb.bind(this)]);
+      return logMethod.apply(this.rollbar, [message, meta, cb]);
     });
   }
 }


### PR DESCRIPTION
Currently this transport only sends the first log to Rollbar. All subsequent logs entirely bypass this transport. This happens because `callback` is never called because the `cb` is not bound to the current `this`.

This regression was introduced in cd6225966 when `cb` was converted from an arrow function (implicit binding) to a function expression (unbound).